### PR TITLE
add discord easy URL

### DIFF
--- a/static/discord
+++ b/static/discord
@@ -1,0 +1,7 @@
+<!doctype html><html lang=en-us>
+<head>
+<meta charset=utf-8>
+<title>redirect</title>
+<meta name=robots content="noindex">
+<meta http-equiv=refresh content="0; url=https://discord.gg/k8xj8d75f6">
+</head></html>


### PR DESCRIPTION
https://owddm.com/discord will redirect to: https://discord.gg/k8xj8d75f6

This gives us an easy to remember URL which can be shared at meetups or online/social etc.