### PR TITLE
fix: center map at better position

### DIFF
--- a/components/Map.vue
+++ b/components/Map.vue
@@ -27,7 +27,7 @@ onMounted(() => {
     if (!mounted) {
       return;
     }
-    lMap = L.map(map.value!).setView([34.95937, 135.57081], 9.4);
+    lMap = L.map(map.value!).setView([34.95937, 136.1], 9.4);
     const gl = new MaplibreLayer({
       attribution: '\u003ca href="https://www.maptiler.com/copyright/" target="_blank"\u003e\u0026copy; MapTiler\u003c/a\u003e \u003ca href="https://www.openstreetmap.org/copyright" target="_blank"\u003e\u0026copy; OpenStreetMap contributors\u003c/a\u003e',
       style: `https://api.maptiler.com/maps/${mapId}/style.json?key=${key}`,


### PR DESCRIPTION
The Map's center position doesn't make events well readable, this way they are at least a little in the box