### PR TITLE
fix: header and footer spacing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -437,12 +437,11 @@ main {
 }
 
 footer {
-	margin-top: 2rem;
 	text-align: center;
 	font-size: .75rem;
 	color: var(--color-text-gray);
 	padding: var(--space);
-	padding-bottom: calc(var(--space) * 2.67)
+	margin: var(--space) 0;
 }
 
 .inactive {

--- a/components/SiteHeader.vue
+++ b/components/SiteHeader.vue
@@ -168,7 +168,6 @@ updateScreenScroll();
   text-transform: upper-case;
 }
 header {
-  height: 4.5rem;
   position: relative;
 }
 .header--container {
@@ -289,6 +288,9 @@ header {
 }
 
 @media only screen and (max-width: 50em) {
+  header {
+    height: 4.2rem;
+  }
   .hamburger-menu {
     display: inline-flex;
     align-self: end;


### PR DESCRIPTION
The header has some odd spacing below the header (should be centered) and the footer consumes a lot of space. This way it should look better