### PR TITLE
fix: header link border bottom

### DIFF
--- a/components/SiteHeader.vue
+++ b/components/SiteHeader.vue
@@ -191,6 +191,10 @@ header {
 .header--links a {
   text-decoration: none;
 }
+.header--links a:hover {
+  border-bottom: 2px solid;
+  border-color: var(--color-gray);
+}
 .header--links ul {
   display: flex;
   flex-direction: row;
@@ -203,9 +207,16 @@ header {
 .active-menu {
   border-bottom: 2px solid transparent;
   border-image: linear-gradient(0.25turn, var(--color-osaka), var(--color-kyoto));
-  border-image: linear-gradient(in oklch 0.25turn, var(--color-osaka), var(--color-kyoto));
   border-image-slice: 1;
 }
+
+@supports (border-image: linear-gradient(in oklch, red, blue)) {
+  .active-menu {
+    border-image: linear-gradient(in oklch 0.25turn, var(--color-osaka), var(--color-kyoto));
+    border-image-slice: 1;
+  }
+}
+
 .header--join-link {
   margin: 0 var(--space);
   flex-grow: 1;
@@ -324,6 +335,9 @@ header {
     width: 100vw;
     margin: 0;
   }
+  .header--links a:hover {
+    border-bottom: none;
+  }
   .header--links > ul {
     list-style-type: none;
     flex-grow: 1;
@@ -338,9 +352,6 @@ header {
     border-left: 0.5rem solid transparent;
     border-bottom: 0;
     display: block;
-  }
-  .header--links > ul > li > a:hover {
-    border-color: var(--color-gray);
   }
   .header--links > ul > li > a.active-menu {
     border-image: linear-gradient(0.5turn, var(--color-osaka), var(--color-kyoto));


### PR DESCRIPTION
In the design the header links are supposed to have a grey hover bottom border. It is missing in the desktop version. Also I noticed that the gradient is not show in firefox, but this way it should.