### PR TITLE
Fixing relevant event display

### DIFF
--- a/utils/events.ts
+++ b/utils/events.ts
@@ -108,7 +108,7 @@ export function getMostRelevantEvent(events: Event[]): Event {
       mostRelevant = event;
       continue;
     }
-    if (!event.isCancelled) {
+    if (event.isCancelled) {
       continue;
     }
     if (inFuture(mostRelevant)) {


### PR DESCRIPTION
On the landing page it showed the wrong events as it would show the cancelled events first. This PR fixes it.