### PR TITLE
Feature/add onbreak status kwddm

### DIFF
--- a/src/components/pages/Index.tsx
+++ b/src/components/pages/Index.tsx
@@ -49,15 +49,19 @@ export const IndexPage = ({ data, url }: IndexPageProps) => {
       gl.addTo(lMap);
       stop = (() => {
         const lMarkers = markers.map((marker) => {
+          const isKwddmMarker = marker.type == "kwddm"
           let title = marker.title
-            ? `<div class="map-event--label"><div class="map-event--title">${marker.title}</div>${marker.subtitle ? `<div class="map-event--info">${marker.subtitlePrefix ? `<strong>${marker.subtitlePrefix}</strong> ` : ""}${marker.subtitle}</div></div>` : ""}`
+            ? `<div class="map-event--label">
+              <div class="map-event--title">${marker.title}</div>
+              ${marker.subtitle ? `<div class="map-event--info">${marker.subtitlePrefix ? `<strong>${marker.subtitlePrefix}</strong> ` : ""}${marker.subtitle}</div>
+              ${isKwddmMarker ? `<div class="map-event--info">(on a break)</div>` : ""}</div>` : ""}`
             : "";
-          const html = `<img src="/images/marker/${marker.type}.svg" class="map-event--image" alt="">${title}`;
+          const html = `<img src="/images/marker/${marker.type}.svg" class="map-event--image " alt="">${title}`;
           return L.marker([marker.lat, marker.lng], {
             icon: L.divIcon({
               iconAnchor: [37, 118],
               iconSize: [74, 120],
-              className: "owddm-map-marker",
+              className: `owddm-map-marker${isKwddmMarker ? " inactive" : "" }`,
               html,
             }),
           }).on("click", () => {

--- a/src/components/pages/Index.tsx
+++ b/src/components/pages/Index.tsx
@@ -23,7 +23,7 @@ export const IndexPage = ({ data, url }: IndexPageProps) => {
             subtitle: formatDate(event.time),
             type: event.group.type,
             target: `/events/${event.id}`,
-            isUpcoming: isUpcoming(event)
+            isUpcoming: isUpcoming(event),
           };
         }),
     [data],
@@ -53,15 +53,19 @@ export const IndexPage = ({ data, url }: IndexPageProps) => {
           let title = marker.title
             ? `<div class="map-event--label">
               <div class="map-event--title">${marker.title}</div>
-              ${marker.subtitle ? `<div class="map-event--info">${marker.subtitlePrefix ? `<strong>${marker.subtitlePrefix}</strong> ` : ""}${marker.subtitle}</div>
-              ${!marker.isUpcoming ? `<div class="map-event--info">(on a break)</div>` : ""}</div>` : ""}`
+              ${
+                marker.subtitle
+                  ? `<div class="map-event--info">${marker.subtitlePrefix ? `<strong>${marker.subtitlePrefix}</strong> ` : ""}${marker.subtitle}</div>
+              ${!marker.isUpcoming ? `<div class="map-event--info">(on a break)</div>` : ""}</div>`
+                  : ""
+              }`
             : "";
           const html = `<img src="/images/marker/${marker.type}.svg" class="map-event--image " alt="">${title}`;
           return L.marker([marker.lat, marker.lng], {
             icon: L.divIcon({
               iconAnchor: [37, 118],
               iconSize: [74, 120],
-              className: `owddm-map-marker${!marker.isUpcoming ? " inactive" : "" }`,
+              className: `owddm-map-marker${!marker.isUpcoming ? " inactive" : ""}`,
               html,
             }),
           }).on("click", () => {

--- a/src/components/pages/Index.tsx
+++ b/src/components/pages/Index.tsx
@@ -1,7 +1,7 @@
 import "leaflet/dist/leaflet.css";
 import { type MapMarker, loadMapLibreLayer } from "../../utils/map.ts";
 import { transform, getLatestEvents } from "../../utils/events.ts";
-import { formatDate } from "../../utils/time.ts";
+import { formatDate, isUpcoming } from "../../utils/time.ts";
 import { useEffect, useMemo, useRef } from "react";
 import { AstroLinkURL } from "../AstroLink.tsx";
 
@@ -23,6 +23,7 @@ export const IndexPage = ({ data, url }: IndexPageProps) => {
             subtitle: formatDate(event.time),
             type: event.group.type,
             target: `/events/${event.id}`,
+            isUpcoming: isUpcoming(event)
           };
         }),
     [data],
@@ -49,19 +50,18 @@ export const IndexPage = ({ data, url }: IndexPageProps) => {
       gl.addTo(lMap);
       stop = (() => {
         const lMarkers = markers.map((marker) => {
-          const isKwddmMarker = marker.type == "kwddm"
           let title = marker.title
             ? `<div class="map-event--label">
               <div class="map-event--title">${marker.title}</div>
               ${marker.subtitle ? `<div class="map-event--info">${marker.subtitlePrefix ? `<strong>${marker.subtitlePrefix}</strong> ` : ""}${marker.subtitle}</div>
-              ${isKwddmMarker ? `<div class="map-event--info">(on a break)</div>` : ""}</div>` : ""}`
+              ${!marker.isUpcoming ? `<div class="map-event--info">(on a break)</div>` : ""}</div>` : ""}`
             : "";
           const html = `<img src="/images/marker/${marker.type}.svg" class="map-event--image " alt="">${title}`;
           return L.marker([marker.lat, marker.lng], {
             icon: L.divIcon({
               iconAnchor: [37, 118],
               iconSize: [74, 120],
-              className: `owddm-map-marker${isKwddmMarker ? " inactive" : "" }`,
+              className: `owddm-map-marker${!marker.isUpcoming ? " inactive" : "" }`,
               html,
             }),
           }).on("click", () => {

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -8,6 +8,7 @@ export type MapMarker = {
   subtitle?: string;
   subtitlePrefix?: string;
   target?: string;
+  isUpcoming?: boolean;
 };
 
 async function createMapLibreLayer(L: any) {


### PR DESCRIPTION
## Description

- Added isUpcoming property to MapMarker class to check if the Marker is in the future
- Added "(on a break)" postfix to the label and made Marker inactive through CSS class

## Motivation and Context

This feature will fix #329

## How Has This Been Tested?

Manually tested because no framework was provided to test the functionality and so I would consider it out of scope.

## Screenshots (if appropriate):
Desktop:
![image](https://github.com/user-attachments/assets/f6c90714-924b-4f1f-95a4-e57efd773172)

Mobile:
![image](https://github.com/user-attachments/assets/2a29b288-fd8e-4591-81e3-a3968c522353)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
