### PR TITLE
fix: Allow new-line+dash lists in the MeetUp editor to be rendered as ULs on the website

### DIFF
--- a/src/components/pages/Event.tsx
+++ b/src/components/pages/Event.tsx
@@ -18,6 +18,9 @@ export type EventPageProps = {
 export const EventPage = ({ url, events, eventId }: EventPageProps) => {
   const event = transform(events).events.find((event) => event.id === eventId)!;
   const image = event.image?.transforms?.m?.webp;
+  // "Lists" created by newlines + dashes in the Meetup editor don't get rendered as
+  // HTML lists without a bit of pre-processing.
+  const description = event!.description.replaceAll("\n\\- ", "\n- ")
   const markers = useMemo(() => {
     if (!event && Array(event).length != 1) return [];
     return Array(event).map((event): MapMarker => {
@@ -65,7 +68,7 @@ export const EventPage = ({ url, events, eventId }: EventPageProps) => {
           </h1>
           {event.isCancelled && <sub>(Cancelled)</sub>}
           <div className="event-description-container">
-            <Marked text={event!.description} />
+            <Marked text={description} />
           </div>
           <div className="event-rsvp-discord-mobile">
             <div>
@@ -107,7 +110,7 @@ export const EventPage = ({ url, events, eventId }: EventPageProps) => {
             </h1>
             {event.isCancelled && <sub className="event-cancelled">(Cancelled)</sub>}
             <div className="event-description-container">
-              <Marked text={event!.description} />
+              <Marked text={description} />
             </div>
           </div>
           <div className="event-details-date-rsvp-discord">

--- a/src/components/pages/Event.tsx
+++ b/src/components/pages/Event.tsx
@@ -20,7 +20,7 @@ export const EventPage = ({ url, events, eventId }: EventPageProps) => {
   const image = event.image?.transforms?.m?.webp;
   // "Lists" created by newlines + dashes in the Meetup editor don't get rendered as
   // HTML lists without a bit of pre-processing.
-  const description = event!.description.replaceAll("\n\\- ", "\n- ")
+  const description = event!.description.replaceAll("\n\\- ", "\n- ");
   const markers = useMemo(() => {
     if (!event && Array(event).length != 1) return [];
     return Array(event).map((event): MapMarker => {


### PR DESCRIPTION
Allow for new-line + dash to be shown as markdown lists, even though strictly speaking the editor in meetup.com doesn't support markdown lists.

## Description

It's a simple `replaceAll`...

## Motivation and Context

Closes #294.

## How Has This Been Tested?

Just visually, in a browser, Firefox on Linux to be exact. It's not like this codebase really has tests...

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/8fd95e35-9ea8-4a29-92cd-7f7665dff2bf)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
