### PR TITLE
Adding global event calendar list with all events.

### DIFF
--- a/src/pages/events.ics.ts
+++ b/src/pages/events.ics.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+import { fetchEvents, transform } from "../utils/events";
+import { createICSFromEvents } from "../utils/ics";
+
+export const GET: APIRoute = async () => {
+  const events = transform(await fetchEvents());
+  return new Response(await createICSFromEvents(events.events), {
+    headers: {
+      "Content-Type": "text/calendar",
+    },
+  });
+};


### PR DESCRIPTION
## Description

Adds a global `/events.ics` iCal file that contains the event information for all events.

## Motivation and Context

Closes #340 

## How Has This Been Tested?

Opened "iCalendar" Mac App and subscribed to calendar.

## Screenshots (if appropriate):

<img width="963" height="295" alt="Screenshot 2025-07-27 at 22 11 51" src="https://github.com/user-attachments/assets/814accf5-46c2-47ec-b0b6-7d0e07d78040" />

## Checklist:

- [x] My code follows the code style of this project.
