### PR TITLE
Configure dependency groups in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,20 @@ updates:
     schedule:
       interval: monthly
     versioning-strategy: increase
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Added groups for all dependencies and GitHub Actions. This will cut down on noise. It avoids major updates too to avoid breaking changes.